### PR TITLE
Add whole .idea folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ Temporary Items
 
 # User-specific stuff
 */.idea/
+.idea/
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/**/usage.statistics.xml


### PR DESCRIPTION
I think we could remove all the lines with ".idea/" from the gitignore file now. I was unsure if you need them, so I left them in.